### PR TITLE
Fix Facade Binding Issue Causing Class Not Found Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `gmail_client` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- Fixed class-not-found error in production by properly binding the facade string key
+- Fixed header method calls to match Saloon v3 API
+
 ## v1.0.1 - 2025-05-12
 
 ### Fixed

--- a/src/GmailClientServiceProvider.php
+++ b/src/GmailClientServiceProvider.php
@@ -45,8 +45,10 @@ class GmailClientServiceProvider extends PackageServiceProvider
             return $client;
         });
 
-        // Register the facade alias
-        $this->app->alias(GmailClient::class, 'gmail-client');
+        // Register binding for the facade
+        $this->app->bind('gmail-client', function ($app) {
+            return $app->make(GmailClient::class);
+        });
     }
 
     /**

--- a/tests/Facades/FacadeBindingTest.php
+++ b/tests/Facades/FacadeBindingTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PartridgeRocks\GmailClient\Tests\Facades;
+
+use Illuminate\Support\Facades\App;
+use PartridgeRocks\GmailClient\Facades\GmailClient;
+use PartridgeRocks\GmailClient\Tests\TestCase;
+
+class FacadeBindingTest extends TestCase
+{
+    public function test_facade_binding_exists()
+    {
+        // Assert that the binding exists in the container
+        $this->assertTrue(App::bound('gmail-client'));
+    }
+
+    public function test_facade_resolves_to_client_instance()
+    {
+        // Get the instance from the facade
+        $instance = GmailClient::getFacadeRoot();
+        
+        // Assert it's the right class
+        $this->assertInstanceOf(\PartridgeRocks\GmailClient\GmailClient::class, $instance);
+    }
+}

--- a/tests/Facades/FacadeBindingTest.php
+++ b/tests/Facades/FacadeBindingTest.php
@@ -18,7 +18,7 @@ class FacadeBindingTest extends TestCase
     {
         // Get the instance from the facade
         $instance = GmailClient::getFacadeRoot();
-        
+
         // Assert it's the right class
         $this->assertInstanceOf(\PartridgeRocks\GmailClient\GmailClient::class, $instance);
     }


### PR DESCRIPTION
## Summary
- Fixed class-not-found error in production by properly binding the 'gmail-client' facade key
- Changed from app->alias() to app->bind() for proper facade resolution
- Added test to verify facade binding exists and resolves correctly

## Test plan
- Run existing facade tests to verify that facades still work
- Run new test specifically for the binding issue
- Verified binding works in container

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bind the 'gmail-client' facade properly and update header methods for Saloon v3 compatibility, adding tests to validate facade resolution

Bug Fixes:
- Bind the 'gmail-client' facade key to the GmailClient class to prevent class-not-found errors
- Update header method calls to match the Saloon v3 API

Documentation:
- Document the facade binding and header method fixes under the unreleased section of CHANGELOG

Tests:
- Add tests to verify the facade binding exists and resolves to a GmailClient instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a class-not-found error in production by properly binding the Gmail client facade.
	- Corrected header method calls to align with the latest Saloon v3 API.

- **Tests**
	- Added tests to verify the correct binding and resolution of the Gmail client facade. 

- **Documentation**
	- Updated the changelog with an "Unreleased" section detailing recent fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->