### PR TITLE
Fix missing fromOAuthError method in AuthenticationException

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,41 @@ Custom exceptions in `src/Exceptions/` for different error scenarios:
 - Mocking of API responses using Saloon's mock capabilities
 - Test fixtures in tests/fixtures/ directory
 
+## Current Development Status
+
+### Known Issues
+
+**OAuth Authentication Bug (v1.0.2)**
+- **Issue**: Missing `fromOAuthError()` method in `AuthenticationException` class
+- **Impact**: OAuth authentication fails with "Call to undefined method" error
+- **GitHub Issue**: #11 - https://github.com/PartridgeRocks/gmail_client/issues/11
+- **Status**: Fix implemented, PR in progress
+
+**Bug Details**:
+- `AuthResource.php` line 40 calls `AuthenticationException::fromOAuthError($e->getMessage())`
+- Method doesn't exist in `AuthenticationException` class
+- Breaks OAuth token exchange process
+
+**Fix Applied**:
+1. Added `fromOAuthError()` method to `AuthenticationException` class
+2. Added `oauth_error` type to `AuthenticationErrorDTO` error messages
+3. Maintains consistent error handling pattern with existing methods
+
+### Testing OAuth Integration
+
+For testing OAuth flows with this package:
+
+1. **Local Development**: Use Cloudflare tunnel for public HTTPS access
+   - Domain: `test.jordanpartridge.us`
+   - Required for OAuth callbacks from Google/GitHub
+
+2. **Environment Configuration**: 
+   ```bash
+   GMAIL_REDIRECT_URI=https://test.jordanpartridge.us/gmail/auth/callback
+   ```
+
+3. **Google Cloud Console**: Add tunnel domain to authorized redirect URIs
+
 ## Additional Notes
 
 - PHP 8.2 is required

--- a/src/Data/Errors/AuthenticationErrorDTO.php
+++ b/src/Data/Errors/AuthenticationErrorDTO.php
@@ -26,6 +26,7 @@ class AuthenticationErrorDTO extends ErrorDTO
             'refresh_failed' => 'Failed to refresh the access token',
             'token_expired' => 'The access token has expired',
             'unauthorized' => 'Unauthorized access to the requested resource',
+            'oauth_error' => 'OAuth authentication process failed',
         ];
 
         return new self(

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -55,6 +55,19 @@ class AuthenticationException extends GmailClientException
     }
 
     /**
+     * Create from an OAuth error
+     */
+    public static function fromOAuthError(string $message): self
+    {
+        $error = AuthenticationErrorDTO::fromType(
+            'oauth_error',
+            $message
+        );
+
+        return new static('OAuth authentication failed: ' . $message, 401, null, $error);
+    }
+
+    /**
      * Create from a 401 response
      */
     public static function fromResponse(array $response, ?string $message = null): self


### PR DESCRIPTION
## Fix Missing fromOAuthError Method in AuthenticationException

Fixes #11 

### Problem
The `AuthResource.php` file attempts to call `AuthenticationException::fromOAuthError()` at line 40, but this method doesn't exist, causing OAuth authentication to fail with:
```
Call to undefined method PartridgeRocks\GmailClient\Exceptions\AuthenticationException::fromOAuthError()
```

### Solution
This PR adds the missing method and required error type to fix the OAuth authentication flow:

1. **Added `fromOAuthError()` method** to `AuthenticationException` class
   - Follows the same pattern as existing static factory methods
   - Takes a string message parameter
   - Returns properly configured exception instance

2. **Added `oauth_error` type** to `AuthenticationErrorDTO` error messages
   - Ensures the error type is recognized by the DTO system
   - Provides appropriate error message for OAuth failures

3. **Updated CLAUDE.md** with current development status and testing information

### Changes Made

#### `src/Exceptions/AuthenticationException.php`
- Added `fromOAuthError(string $message): self` static method
- Maintains consistent error handling pattern with existing methods

#### `src/Data/Errors/AuthenticationErrorDTO.php`  
- Added `'oauth_error' => 'OAuth authentication process failed'` to error messages array

#### `CLAUDE.md`
- Documented the bug and fix status
- Added OAuth testing information for development

### Testing
- Method signature matches the call in `AuthResource.php` line 40
- Error handling follows established patterns in the codebase
- No breaking changes to existing functionality

### Impact
- ✅ Fixes broken OAuth authentication flow
- ✅ Enables Gmail API integration to work properly  
- ✅ Maintains backward compatibility
- ✅ Follows existing code patterns and conventions

This is a critical bug fix that makes the package functional for OAuth authentication.